### PR TITLE
Remove duplicated definitions

### DIFF
--- a/wdmngr/wd_queue_memory.c
+++ b/wdmngr/wd_queue_memory.c
@@ -26,9 +26,6 @@
 #define MAXBLOCKSIZE   0x90000
 #define MAXRSVMEM      0x400000
 
-#define MAXBLOCKSIZE   0x90000
-#define MAXRSVMEM      0x400000
-
 const char *g_alg_type[] = {
     "rsa",
     "dh",


### PR DESCRIPTION
`MAXBLOCKSIZE` and `MAXRSVMEM` constant definitions are duplicated.