### PR TITLE
update KAE to version 1.3.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ ENGINE_INSTALL_PATH := $(OPENSSL_WORK_PATH)/lib/engines-1.1
 CC=gcc
 
 LIBNAME := libkae.so
-VERSION = 1.3.6
+VERSION = 1.3.8
 TARGET = ${LIBNAME}.${VERSION}
 SOFTLINK = kae.so
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Clone OpenSSL from Github at the following location:
 You are advised to check out and build the OpenSSL 1.1.1a git tag specified in the release notes.
 Versions of OpenSSL before OpenSSL 1.1.0 are not supported.
 
-The `--prefix` can be used with the `./config` command to specify the location that `make install` will copy files to. Please see the OpenSSL INSTALL file for full details on usage of the `--prefix` option.
+Note: You are not advised to install the accelerated version of OpenSSL as your default system library. Otherwise, acceleration may be used unexpectedly by other applications on the system, resulting in undesired/unsupported behavior. The `--prefix` can be used with the `./config` command to specify the location that `make install` will copy files to. Please see the OpenSSL INSTALL file for full details on usage of the `--prefix` option.
 
 By default, we usually install OpenSSL as follows:
 

--- a/alg/digests/sec_digests_soft.c
+++ b/alg/digests/sec_digests_soft.c
@@ -92,26 +92,18 @@ void sec_digests_soft_work(sec_digest_priv_t *md_ctx, int len, unsigned char *di
     if (md_ctx->soft_ctx == NULL) {
         md_ctx->soft_ctx = EVP_MD_CTX_new();
     }
-    if (md_ctx->last_update_buff == NULL) {
-        md_ctx->last_update_buff = (unsigned char *)kae_malloc(len * sizeof(unsigned char));
-    }
-    if (md_ctx->last_update_buff == NULL) {
-        US_ERR("digests soft work:malloc last_update_buff filed!");
-    }
-
+    
     (void)sec_digests_soft_init(md_ctx->soft_ctx, md_ctx->e_nid);
-    (void)sec_digests_soft_update(md_ctx->soft_ctx, md_ctx->last_update_buff, len, md_ctx->e_nid);
+    if (len != 0) {
+        (void)sec_digests_soft_update(md_ctx->soft_ctx, md_ctx->last_update_buff, len, md_ctx->e_nid);
+    }
     (void)sec_digests_soft_final(md_ctx->soft_ctx, digest, md_ctx->e_nid);
 
     if (md_ctx->soft_ctx != NULL) {
         EVP_MD_CTX_free(md_ctx->soft_ctx);
         md_ctx->soft_ctx = NULL;
     }
-
-    if (md_ctx->last_update_buff != NULL) {
-        kae_free(md_ctx->last_update_buff);
-    }
-
+    
     return;
 }
 

--- a/alg/digests/sec_digests_wd.c
+++ b/alg/digests/sec_digests_wd.c
@@ -156,10 +156,6 @@ void wd_digests_put_engine_ctx(digest_engine_ctx_t* e_digest_ctx)
         return;
     }
 
-    if (e_digest_ctx->md_ctx->last_update_buff != NULL) {
-        kae_free(e_digest_ctx->md_ctx->last_update_buff);
-    }
-
     if (e_digest_ctx->wd_ctx != NULL) {
         wcrypto_del_digest_ctx(e_digest_ctx->wd_ctx);
         e_digest_ctx->wd_ctx = NULL;
@@ -205,7 +201,6 @@ void wd_digests_set_input_data(digest_engine_ctx_t *e_digest_ctx)
     // fill engine ctx opdata
     sec_digest_priv_t* md_ctx = e_digest_ctx->md_ctx;
 
-    kae_memcpy((uint8_t *)e_digest_ctx->op_data.in, md_ctx->in, md_ctx->do_digest_len);
     e_digest_ctx->op_data.in_bytes = md_ctx->do_digest_len;
     e_digest_ctx->op_data.out_bytes = md_ctx->out_len;
 

--- a/kae.spec
+++ b/kae.spec
@@ -1,6 +1,6 @@
 Name:          libkae
 Summary:       Huawei Kunpeng Accelerator Engine
-Version:       1.3.6
+Version:       1.3.8
 Release:       1%dist
 License:       Apache-2.0
 Source:        %{name}-%{version}.tar.gz


### PR DESCRIPTION
update KAE to version 1.3.8.
fixed the problem of high memory bandwidth of md5 in large package scenarios.