### PR TITLE
libkae: fix build warning on aarch64

### DIFF
--- a/alg/pkey/hpre_rsa.c
+++ b/alg/pkey/hpre_rsa.c
@@ -263,6 +263,8 @@ static int hpre_rsa_public_encrypt(int flen, const unsigned char *from,
     BIGNUM *ret_bn  = NULL;
     hpre_engine_ctx_t *eng_ctx = NULL;
     unsigned char *in_buf = NULL;
+    BN_CTX *bn_ctx = NULL;
+    int num_bytes = 0;
 
     if (hpre_rsa_check_para(flen, from, to, rsa) != HPRE_CRYPTO_SUCC) {
         return HPRE_CRYPTO_FAIL;
@@ -285,13 +287,13 @@ static int hpre_rsa_public_encrypt(int flen, const unsigned char *from,
     GOTOEND_IF(ret != HPRE_CRYPTO_SUCC, "check public key fail",
         KAE_F_HPRE_RSA_PUBENC, KAE_R_PUBLIC_KEY_INVALID);
 
-    BN_CTX *bn_ctx = BN_CTX_new();
+    bn_ctx = BN_CTX_new();
     GOTOEND_IF(bn_ctx == NULL, "bn_ctx MALLOC FAILED!",
         KAE_F_HPRE_RSA_PUBENC, KAE_R_MALLOC_FAILURE);
 
     BN_CTX_start(bn_ctx);
     ret_bn = BN_CTX_get(bn_ctx);
-    int num_bytes = BN_num_bytes(n);
+    num_bytes = BN_num_bytes(n);
     in_buf = (unsigned char *)OPENSSL_malloc(num_bytes);
     GOTOEND_IF(ret_bn == NULL || in_buf == NULL, "PUBLIC_ENCRYPT RSA MALLOC FAILED!",
         KAE_F_HPRE_RSA_PUBENC, KAE_R_MALLOC_FAILURE);
@@ -349,6 +351,8 @@ static int hpre_rsa_private_encrypt(int flen, const unsigned char *from,
     const BIGNUM *dmq1 = (const BIGNUM *)NULL;
     const BIGNUM *iqmp = (const BIGNUM *)NULL;
     unsigned char *in_buf = (unsigned char *)NULL;
+    BN_CTX *bn_ctx = NULL;
+    int num_bytes = 0;
 
     if (hpre_rsa_check_para(flen, from, to, rsa) != HPRE_CRYPTO_SUCC) {
         return HPRE_CRYPTO_FAIL;
@@ -367,7 +371,7 @@ static int hpre_rsa_private_encrypt(int flen, const unsigned char *from,
         goto end_soft;
     }
 
-    BN_CTX *bn_ctx = BN_CTX_new();
+    bn_ctx = BN_CTX_new();
     GOTOEND_IF(bn_ctx == NULL, "PRI_ENC MALLOC_FAILURE ",
         KAE_F_HPRE_RSA_PRIENC, KAE_R_MALLOC_FAILURE);
 
@@ -378,7 +382,7 @@ static int hpre_rsa_private_encrypt(int flen, const unsigned char *from,
     RSA_get0_crt_params(rsa, &dmp1, &dmq1, &iqmp);
     int version = RSA_get_version(rsa);
     RSA_get0_key(rsa, &n, &e, &d);
-    int num_bytes = BN_num_bytes(n);
+    num_bytes = BN_num_bytes(n);
     in_buf = (unsigned char *)OPENSSL_malloc(num_bytes);
     GOTOEND_IF(bn_ret == NULL || in_buf == NULL, "OpenSSL malloc failure",
         KAE_F_HPRE_RSA_PRIENC, KAE_R_MALLOC_FAILURE);

--- a/utils/engine_log.c
+++ b/utils/engine_log.c
@@ -164,8 +164,9 @@ void ENGINE_LOG_LIMIT(int level, int times, int limit, const char *fmt, ...)
         fprintf(g_kae_debug_log_file, "\n");
         if (ftell(g_kae_debug_log_file) > KAE_LOG_MAX_SIZE) {
             kae_save_log(g_kae_debug_log_file);
-            ftruncate(g_kae_debug_log_file->_fileno, 0);
-            fseek(g_kae_debug_log_file, 0, SEEK_SET);
+            if (ftruncate(g_kae_debug_log_file->_fileno, 0) == 0) {
+                fseek(g_kae_debug_log_file, 0, SEEK_SET);
+            }
         }
         pthread_mutex_unlock(&g_debug_file_mutex);
         flock(g_kae_debug_log_file->_fileno, LOCK_UN);

--- a/utils/engine_log.h
+++ b/utils/engine_log.h
@@ -70,8 +70,9 @@ void ENGINE_LOG_LIMIT(int level, int times, int limit, const char *fmt, ...);
         }                                                                                               \
         if (ftell(g_kae_debug_log_file) > KAE_LOG_MAX_SIZE) {                                           \
             kae_save_log(g_kae_debug_log_file);                                                         \
-            ftruncate(g_kae_debug_log_file->_fileno, 0);                                                \
-            fseek(g_kae_debug_log_file, 0, SEEK_SET);                                                   \
+            if (ftruncate(g_kae_debug_log_file->_fileno, 0) == 0) {                                     \
+                fseek(g_kae_debug_log_file, 0, SEEK_SET);                                               \
+            }                                                                                           \
         }                                                                                               \
             pthread_mutex_unlock(&g_debug_file_mutex);                                                  \
             flock(g_kae_debug_log_file->_fileno, LOCK_UN);                                              \


### PR DESCRIPTION
This patch to fix below error on aarch64
[   34s] ./utils/engine_log.h:73:13: error: ignoring return value of 'ftruncate' declared with attribute 'warn_unused_result' [-Werror=unused-result]
[   34s]    73 |             ftruncate(g_kae_debug_log_file->_fileno, 0);                                                \
[   34s]       |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

[   84s] alg/pkey/hpre_rsa.c: In function 'hpre_rsa_private_encrypt':
[   84s] alg/pkey/hpre_rsa.c:546:5: error: 'num_bytes' may be used uninitialized in this function [-Werror=maybe-uninitialized]
[   84s]   546 |     hpre_free_bn_ctx_buf(bn_ctx, in_buf, num_bytes);
[   84s]       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[   84s] alg/pkey/hpre_rsa.c: In function 'hpre_rsa_public_encrypt':
[   84s] alg/pkey/hpre_rsa.c:440:5: error: 'num_bytes' may be used uninitialized in this function [-Werror=maybe-uninitialized]
[   84s]   440 |     hpre_free_bn_ctx_buf(bn_ctx, in_buf, num_bytes);
[   84s]       |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[   84s] alg/pkey/hpre_rsa.c:440:5: error: 'bn_ctx' may be used uninitialized in this function [-Werror=maybe-uninitialized]

There is no functional change.

Signed-off-by: Chenxi Mao <chenxi.mao@suse.com>